### PR TITLE
fix: error on inaccessible folders

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,8 +58,8 @@ try {
     (error) => {
       if (error) {
         console.error(
+          chalk.bgRedBright.whiteBright(' ERROR '),
           chalk.redBright(
-            chalk.bgRedBright(chalk.whiteBright(' ERROR ')),
             'Unable to write the output file',
             chalk.bold(argv.output) + '.'
           )
@@ -67,7 +67,7 @@ try {
         console.error(error);
       } else {
         console.log(
-          chalk.bgGray(chalk.whiteBright(' INFO ')),
+          chalk.bgGreen.whiteBright(' SUCCESS '),
           chalk.white(
             'The route builder has been successfully exported to'
           ),
@@ -79,7 +79,7 @@ try {
 } catch (error) {
   console.error(
     chalk.redBright(
-      chalk.bgRedBright(chalk.whiteBright(' ERROR ')),
+      chalk.bgRedBright.whiteBright(' ERROR '),
       'Unable to build the route builder.'
     )
   );

--- a/src/utilities/search.ts
+++ b/src/utilities/search.ts
@@ -6,7 +6,13 @@ import {
 import { isAuxiliaryNode, isPage } from './checks';
 import { readdirSync } from 'node:fs';
 import { parse, resolve } from 'node:path';
-import { INDEX_FILE_NAME_REGEX } from '../constants';
+import {
+  DEFAULT_APP_FOLDER_PATH,
+  DEFAULT_PAGES_FOLDER_PATH,
+  INDEX_FILE_NAME_REGEX,
+} from '../constants';
+import { Dirent } from 'fs';
+import chalk from 'chalk';
 
 /**
  * Determines the route tree node type from the node name.
@@ -39,9 +45,24 @@ export const buildRouteTree = (
   path: string,
   routeFolderType: RouteFolderType
 ): RouteTreeNode => {
-  const dirents = readdirSync(path, {
-    withFileTypes: true,
-  });
+  let dirents: Dirent[] = [];
+
+  try {
+    dirents = readdirSync(path, {
+      withFileTypes: true,
+    });
+  } catch (error) {
+    console.log(
+      chalk.bgGray.whiteBright(' INFO '),
+      chalk.white('No routes found in'),
+      chalk.bold(
+        routeFolderType === RouteFolderType.App
+          ? DEFAULT_APP_FOLDER_PATH
+          : DEFAULT_PAGES_FOLDER_PATH
+      ),
+      chalk.white("(directory doesn't exist or is inaccessible).")
+    );
+  }
 
   const baseName = parse(path).name;
 


### PR DESCRIPTION
Fixes an incorrect behavior of `next-scout`. When either `app` or `pages` folder was non-existent or inaccessible, the `next-scout` run failed.